### PR TITLE
Align clients table schema with API

### DIFF
--- a/database/migrations/2023_01_05_044027_create_clients_table.php
+++ b/database/migrations/2023_01_05_044027_create_clients_table.php
@@ -15,17 +15,27 @@ return new class extends Migration
     {
         Schema::create('clients', function (Blueprint $table) {
             $table->id();
-            $table->string('first_name');
-            $table->string('last_name');
-            $table->string('company');
-            $table->string('email')->unique();
-            $table->bigInteger('phone');
-            $table->string('password');
-            $table->string('address');
-            $table->string('city');
-            $table->string('state');
-            $table->string('country');
-            $table->integer('zip');
+            $table->string('name');
+            $table->string('email')->nullable()->unique();
+            $table->string('password')->nullable();
+            $table->string('phone')->nullable();
+            $table->string('country_code')->nullable();
+            $table->text('address')->nullable();
+            $table->string('company')->nullable();
+            $table->string('website')->nullable();
+            $table->text('notes')->nullable();
+            $table->tinyInteger('status')->default(1);
+            $table->string('city')->nullable();
+            $table->string('state')->nullable();
+            $table->string('country')->nullable();
+            $table->string('zip')->nullable();
+            $table->date('dob')->nullable();
+            $table->date('doj')->nullable();
+            $table->text('internal_purpose')->nullable();
+            $table->string('acc_mail')->nullable();
+            $table->string('photo')->nullable();
+            $table->unsignedBigInteger('admin_id')->nullable();
+            $table->foreign('admin_id')->references('id')->on('admins')->onDelete('set null');
             $table->timestamps();
         });
     }

--- a/database/migrations/2024_07_09_110959_make_fields_nullable_in_clients_table.php
+++ b/database/migrations/2024_07_09_110959_make_fields_nullable_in_clients_table.php
@@ -12,17 +12,39 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('clients', function (Blueprint $table) {
-            $table->string('company')->nullable()->change();
-            $table->string('phone')->nullable()->change();
-            $table->string('country_code')->nullable()->change();
-            $table->string('password')->nullable()->change();
-            $table->date('dob')->nullable()->change();
-            $table->date('doj')->nullable()->change();
-            $table->string('address')->nullable()->change();
-            $table->string('city')->nullable()->change();
-            $table->string('state')->nullable()->change();
-            $table->string('country')->nullable()->change();
-            $table->string('zip')->nullable()->change();
+            if (Schema::hasColumn('clients', 'company')) {
+                $table->string('company')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'phone')) {
+                $table->string('phone')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'country_code')) {
+                $table->string('country_code')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'password')) {
+                $table->string('password')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'dob')) {
+                $table->date('dob')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'doj')) {
+                $table->date('doj')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'address')) {
+                $table->text('address')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'city')) {
+                $table->string('city')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'state')) {
+                $table->string('state')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'country')) {
+                $table->string('country')->nullable()->change();
+            }
+            if (Schema::hasColumn('clients', 'zip')) {
+                $table->string('zip')->nullable()->change();
+            }
         });
     }
 
@@ -32,17 +54,39 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('clients', function (Blueprint $table) {
-            $table->string('company')->change();
-            $table->string('phone')->change();
-            $table->string('country_code')->change();
-            $table->string('password')->change();
-            $table->date('dob')->change();
-            $table->date('doj')->change();
-            $table->string('address')->change();
-            $table->string('city')->change();
-            $table->string('state')->change();
-            $table->string('country')->change();
-            $table->string('zip')->change();
+            if (Schema::hasColumn('clients', 'company')) {
+                $table->string('company')->change();
+            }
+            if (Schema::hasColumn('clients', 'phone')) {
+                $table->string('phone')->change();
+            }
+            if (Schema::hasColumn('clients', 'country_code')) {
+                $table->string('country_code')->change();
+            }
+            if (Schema::hasColumn('clients', 'password')) {
+                $table->string('password')->change();
+            }
+            if (Schema::hasColumn('clients', 'dob')) {
+                $table->date('dob')->change();
+            }
+            if (Schema::hasColumn('clients', 'doj')) {
+                $table->date('doj')->change();
+            }
+            if (Schema::hasColumn('clients', 'address')) {
+                $table->text('address')->change();
+            }
+            if (Schema::hasColumn('clients', 'city')) {
+                $table->string('city')->change();
+            }
+            if (Schema::hasColumn('clients', 'state')) {
+                $table->string('state')->change();
+            }
+            if (Schema::hasColumn('clients', 'country')) {
+                $table->string('country')->change();
+            }
+            if (Schema::hasColumn('clients', 'zip')) {
+                $table->string('zip')->change();
+            }
         });
     }
 };


### PR DESCRIPTION
## Summary
- Expand initial clients table migration to include API fields like name, contact details, and admin ownership
- Guard nullable-field migration with column existence checks to avoid schema mismatches

## Testing
- `php -l database/migrations/2023_01_05_044027_create_clients_table.php`
- `php -l database/migrations/2024_07_09_110959_make_fields_nullable_in_clients_table.php`
- `php artisan test` *(fails: Command "test" is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68b0bb0cb1dc83208ac103fd0fb07f58