### PR TITLE
Fix task dropdown loading and project display

### DIFF
--- a/vendorconnect-frontend/src/app/tasks/[id]/edit/page.tsx
+++ b/vendorconnect-frontend/src/app/tasks/[id]/edit/page.tsx
@@ -219,26 +219,18 @@ export default function EditTaskPage() {
         apiClient.get('/statuses?per_page=all'),
         apiClient.get('/priorities?per_page=all'),
       ]);
-      
-      // Debug API responses
-      console.log('Statuses API Response:', statusesRes.data);
-      console.log('Priorities API Response:', prioritiesRes.data);
-      console.log('Projects API Response:', projectsRes.data);
-      console.log('Clients API Response:', clientsRes.data);
-      
-      const statusesData = statusesRes.data.data || statusesRes.data || [];
-      const prioritiesData = prioritiesRes.data.data || prioritiesRes.data || [];
-      const projectsData = projectsRes.data.data || projectsRes.data || [];
-      const clientsData = clientsRes.data.data || clientsRes.data || [];
-      const usersData = usersRes.data.data || usersRes.data || [];
-      const taskTypesData = taskTypesRes.data.data || taskTypesRes.data || [];
-      const templatesData = templatesRes.data.data || templatesRes.data || [];
-      
-      console.log('Processed Statuses Data:', statusesData);
-      console.log('Processed Priorities Data:', prioritiesData);
-      console.log('Processed Projects Data:', projectsData);
-      console.log('Processed Clients Data:', clientsData);
-      
+
+      // Helper to consistently extract array data from API responses
+      const extractData = (res: any) => res?.data?.data?.data || res?.data?.data || res?.data || [];
+
+      const statusesData = extractData(statusesRes);
+      const prioritiesData = extractData(prioritiesRes);
+      const projectsData = extractData(projectsRes);
+      const clientsData = extractData(clientsRes);
+      const usersData = extractData(usersRes);
+      const taskTypesData = extractData(taskTypesRes);
+      const templatesData = extractData(templatesRes);
+
       setUsers(usersData);
       setClients(clientsData);
       setProjects(projectsData);

--- a/vendorconnect-frontend/src/app/tasks/page.tsx
+++ b/vendorconnect-frontend/src/app/tasks/page.tsx
@@ -91,13 +91,10 @@ export default function TasksPage() {
       if (searchQuery) {
         params.append('search', searchQuery);
       }
-      
+
       const response = await apiClient.get(`/tasks?${params.toString()}`);
-      // Handle paginated response
-      const taskData = response.data.data || [];
-      console.log('Tasks API Response:', response.data);
-      console.log('Task Data:', taskData);
-      console.log('First task project:', taskData[0]?.project);
+      // Handle varying pagination structures
+      const taskData = response.data?.data?.data || response.data?.data || response.data || [];
       setTasks(Array.isArray(taskData) ? taskData : []);
     } catch (error) {
       console.error('Failed to fetch tasks:', error);
@@ -217,11 +214,11 @@ export default function TasksPage() {
                 <CardContent>
                   <div className="space-y-3">
                     {/* Project */}
-                    {task.project && (
+                    {(task.project || task.project_title) && (
                       <div className="flex items-center gap-2 text-sm">
                         <Tag className="h-4 w-4 text-muted-foreground" />
                         <span className="truncate text-blue-600">
-                          {task.project.title || 'Unnamed Project'}
+                          {task.project?.title || (task as any).project_title || 'Unnamed Project'}
                         </span>
                       </div>
                     )}


### PR DESCRIPTION
## Summary
- Ensure task edit dropdowns load correctly by normalizing API responses
- Stabilize task list fetch logic and show actual project titles instead of 'Unnamed Project'

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b168645b508320b7bf2cd6f2300261