### PR TITLE
Fix task dropdown loading and project display

### DIFF
--- a/vendorconnect-frontend/src/app/clients/[id]/page.tsx
+++ b/vendorconnect-frontend/src/app/clients/[id]/page.tsx
@@ -107,7 +107,7 @@ export default function ClientDetailPage() {
       setClient(filteredClient);
 
       const projectsData = projectsResponse.data.data?.data || projectsResponse.data.data || [];
-      const tasksData = tasksResponse.data.data || [];
+      const tasksData = tasksResponse.data.data?.data || tasksResponse.data.data || [];
       
       console.log('🔍 [DEBUG] Projects data to set:', projectsData);
       console.log('🔍 [DEBUG] Tasks data to set:', tasksData);

--- a/vendorconnect-frontend/src/app/portfolio/[id]/page.tsx
+++ b/vendorconnect-frontend/src/app/portfolio/[id]/page.tsx
@@ -23,6 +23,7 @@ import {
   Plus
 } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
+import getFileUrl from '@/lib/file-utils';
 
 interface Portfolio {
   id: number;
@@ -84,7 +85,8 @@ export default function PortfolioDetailPage() {
     try {
       setLoading(true);
       const response = await apiClient.get(`/portfolios/${portfolioId}`);
-      setPortfolio(response.data.data);
+      const portfolioData = response.data.data?.data || response.data.data || response.data;
+      setPortfolio(portfolioData);
     } catch (error) {
       console.error('Failed to fetch portfolio:', error);
       toast.error('Failed to load portfolio details');
@@ -340,7 +342,7 @@ export default function PortfolioDetailPage() {
                           <Button
                             variant="outline"
                             size="sm"
-                            onClick={() => window.open(file.original_url, '_blank')}
+                            onClick={() => window.open(getFileUrl(file.original_url), '_blank')}
                           >
                             <Eye className="h-4 w-4 mr-1" />
                             View
@@ -350,7 +352,7 @@ export default function PortfolioDetailPage() {
                             size="sm"
                             onClick={() => {
                               const link = document.createElement('a');
-                              link.href = file.original_url;
+                              link.href = getFileUrl(file.original_url);
                               link.download = file.file_name;
                               link.click();
                             }}

--- a/vendorconnect-frontend/src/app/portfolio/page.tsx
+++ b/vendorconnect-frontend/src/app/portfolio/page.tsx
@@ -23,6 +23,7 @@ import {
   Archive
 } from 'lucide-react';
 import { apiClient } from '@/lib/api-client';
+import getFileUrl from '@/lib/file-utils';
 
 interface Portfolio {
   id: number;
@@ -349,7 +350,7 @@ export default function PortfolioPage() {
                         <Button
                           variant="outline"
                           size="sm"
-                          onClick={() => window.open(portfolio.main_file?.original_url, '_blank')}
+                          onClick={() => window.open(getFileUrl(portfolio.main_file?.original_url), '_blank')}
                         >
                           <Download className="h-4 w-4" />
                         </Button>

--- a/vendorconnect-frontend/src/app/tasks/[id]/edit/page.tsx
+++ b/vendorconnect-frontend/src/app/tasks/[id]/edit/page.tsx
@@ -219,26 +219,18 @@ export default function EditTaskPage() {
         apiClient.get('/statuses?per_page=all'),
         apiClient.get('/priorities?per_page=all'),
       ]);
-      
-      // Debug API responses
-      console.log('Statuses API Response:', statusesRes.data);
-      console.log('Priorities API Response:', prioritiesRes.data);
-      console.log('Projects API Response:', projectsRes.data);
-      console.log('Clients API Response:', clientsRes.data);
-      
-      const statusesData = statusesRes.data.data || statusesRes.data || [];
-      const prioritiesData = prioritiesRes.data.data || prioritiesRes.data || [];
-      const projectsData = projectsRes.data.data || projectsRes.data || [];
-      const clientsData = clientsRes.data.data || clientsRes.data || [];
-      const usersData = usersRes.data.data || usersRes.data || [];
-      const taskTypesData = taskTypesRes.data.data || taskTypesRes.data || [];
-      const templatesData = templatesRes.data.data || templatesRes.data || [];
-      
-      console.log('Processed Statuses Data:', statusesData);
-      console.log('Processed Priorities Data:', prioritiesData);
-      console.log('Processed Projects Data:', projectsData);
-      console.log('Processed Clients Data:', clientsData);
-      
+
+      // Helper to consistently extract array data from API responses
+      const extractData = (res: any) => res?.data?.data?.data || res?.data?.data || res?.data || [];
+
+      const statusesData = extractData(statusesRes);
+      const prioritiesData = extractData(prioritiesRes);
+      const projectsData = extractData(projectsRes);
+      const clientsData = extractData(clientsRes);
+      const usersData = extractData(usersRes);
+      const taskTypesData = extractData(taskTypesRes);
+      const templatesData = extractData(templatesRes);
+
       setUsers(usersData);
       setClients(clientsData);
       setProjects(projectsData);

--- a/vendorconnect-frontend/src/app/tasks/[id]/page.tsx
+++ b/vendorconnect-frontend/src/app/tasks/[id]/page.tsx
@@ -12,6 +12,7 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import apiClient from '@/lib/api-client';
+import getFileUrl from '@/lib/file-utils';
 import { ArrowLeft, Edit, Trash2, Calendar, User, Tag, MessageSquare, Paperclip, Clock, CheckCircle, AlertCircle, Plus, Edit3, AlertTriangle, FileText, Eye, X } from 'lucide-react';
 import { format } from 'date-fns';
 import { toast } from 'react-hot-toast';
@@ -1383,7 +1384,7 @@ export default function TaskDetailPage() {
                     {selectedDeliverable.media.map((file: any) => (
                       <a
                         key={file.id}
-                        href={file.original_url}
+                        href={getFileUrl(file.original_url)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="flex items-center gap-2 text-blue-600 hover:text-blue-800 text-sm"

--- a/vendorconnect-frontend/src/app/tasks/page.tsx
+++ b/vendorconnect-frontend/src/app/tasks/page.tsx
@@ -91,13 +91,10 @@ export default function TasksPage() {
       if (searchQuery) {
         params.append('search', searchQuery);
       }
-      
+
       const response = await apiClient.get(`/tasks?${params.toString()}`);
-      // Handle paginated response
-      const taskData = response.data.data || [];
-      console.log('Tasks API Response:', response.data);
-      console.log('Task Data:', taskData);
-      console.log('First task project:', taskData[0]?.project);
+      // Handle varying pagination structures
+      const taskData = response.data?.data?.data || response.data?.data || response.data || [];
       setTasks(Array.isArray(taskData) ? taskData : []);
     } catch (error) {
       console.error('Failed to fetch tasks:', error);
@@ -217,11 +214,11 @@ export default function TasksPage() {
                 <CardContent>
                   <div className="space-y-3">
                     {/* Project */}
-                    {task.project && (
+                    {(task.project || task.project_title) && (
                       <div className="flex items-center gap-2 text-sm">
                         <Tag className="h-4 w-4 text-muted-foreground" />
                         <span className="truncate text-blue-600">
-                          {task.project.title || 'Unnamed Project'}
+                          {task.project?.title || (task as any).project_title || 'Unnamed Project'}
                         </span>
                       </div>
                     )}

--- a/vendorconnect-frontend/src/app/templates/page.tsx
+++ b/vendorconnect-frontend/src/app/templates/page.tsx
@@ -132,9 +132,9 @@ export default function TemplatesPage() {
                 <CardHeader>
                   <div className="flex items-start justify-between">
                     <div className="space-y-1">
-                      <CardTitle className="text-lg flex items-center gap-2">
+                      <CardTitle className="text-lg flex items-center gap-2 overflow-hidden">
                         <FileText className="h-5 w-5 text-muted-foreground" />
-                        {template.title}
+                        <span className="truncate">{template.title}</span>
                       </CardTitle>
                       {template.task_type && (
                         <CardDescription>
@@ -161,7 +161,7 @@ export default function TemplatesPage() {
                   </div>
                   
                   {/* Actions */}
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <Button
                       size="sm"
                       variant="outline"

--- a/vendorconnect-frontend/src/lib/file-utils.ts
+++ b/vendorconnect-frontend/src/lib/file-utils.ts
@@ -1,0 +1,7 @@
+export const getFileUrl = (url: string): string => {
+  if (!url) return '';
+  const base = process.env.NEXT_PUBLIC_API_URL?.replace(/\/api\/v1$/, '') || '';
+  return url.startsWith('http') ? url : `${base}${url}`;
+};
+
+export default getFileUrl;


### PR DESCRIPTION
## Summary
- Ensure task edit dropdowns load correctly by normalizing API responses
- Stabilize task list fetch logic and show actual project titles instead of 'Unnamed Project'
- Normalize client task and portfolio fetch results and resolve portfolio view failures
- Improve template card layout to prevent icon overflow
- Prefix media URLs with backend host so deliverable uploads and portfolio files open correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b168645b508320b7bf2cd6f2300261