### PR TITLE
Fix missing brace in task detail page

### DIFF
--- a/vendorconnect-frontend/src/app/tasks/[id]/page.tsx
+++ b/vendorconnect-frontend/src/app/tasks/[id]/page.tsx
@@ -263,10 +263,11 @@ export default function TaskDetailPage() {
                    });
                    setChecklistCompleted({...completedMap});
                  }
-               } catch (error) {
-                 console.error('Failed to load checklist states:', error);
-               }
-               }
+              } catch (error) {
+                console.error('Failed to load checklist states:', error);
+              }
+              }
+            }
 
       // Load deliverables
       if (taskData.deliverables) {


### PR DESCRIPTION
## Summary
- close unbalanced brackets in task detail page to restore compilation

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(fails: Failed to fetch `Inter` font)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d86b29e08320a42cfc8b6b383a0c