### PR TITLE
Use environment variable for API base URL

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -3,7 +3,7 @@
 ## Overview
 This document provides comprehensive documentation for all VendorConnect API endpoints, including request/response formats, database operations, and frontend page associations.
 
-**Base URL**: `https://vc.themastermind.com.au/api/v1`
+**Base URL**: Configured via the `NEXT_PUBLIC_API_URL` environment variable (for example, `https://example.com/api/v1`)
 
 **Last Updated**: August 29, 2025
 

--- a/FRONTEND_API_DOCUMENTATION.md
+++ b/FRONTEND_API_DOCUMENTATION.md
@@ -3,7 +3,7 @@
 ## Overview
 This document provides comprehensive documentation of all frontend pages in the VendorConnect application, including their API calls, data usage, and variable mappings.
 
-**Base URL**: `https://vc.themastermind.com.au/api/v1`
+**Base URL**: Defined in the `NEXT_PUBLIC_API_URL` environment variable (e.g., `https://example.com/api/v1`)
 **Frontend Framework**: Next.js 14 with TypeScript
 **State Management**: Zustand (auth-store)
 **UI Library**: Custom components with Lucide React icons
@@ -766,7 +766,7 @@ interface TaskType {
 ## 🔧 Technical Implementation Notes
 
 ### API Client Configuration
-- **Base URL**: `https://vc.themastermind.com.au/api/v1`
+- **Base URL**: Provided by the `NEXT_PUBLIC_API_URL` environment variable
 - **Headers**: Automatic Content-Type and Authorization
 - **Interceptors**: Request and response interceptors for auth and error handling
 - **Error Handling**: Centralized error handling with toast notifications

--- a/vendorconnect-frontend/next.config.js
+++ b/vendorconnect-frontend/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
     domains: ['vc.themastermind.com.au', 'localhost'],
   },
   env: {
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL || 'https://vc.themastermind.com.au/api/v1',
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
   },
 }
 

--- a/vendorconnect-frontend/src/lib/api-client.ts
+++ b/vendorconnect-frontend/src/lib/api-client.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import { toast } from 'react-hot-toast';
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://vc.themastermind.com.au/api/v1';
+const API_URL = process.env.NEXT_PUBLIC_API_URL;
+
+if (!API_URL) {
+  throw new Error('NEXT_PUBLIC_API_URL is not defined');
+}
 
 export const apiClient = axios.create({
   baseURL: API_URL,


### PR DESCRIPTION
## Summary
- load API client base URL from NEXT_PUBLIC_API_URL
- remove hard-coded fallback from Next config
- document API base URL configuration via environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive configuration)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b81200112c8320849b72644d0d1571